### PR TITLE
Separating instruction for unified IR and -G=3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,12 @@ The intended use is in graphql servers, to reduce the number of queries being se
 
 ## example
 
-run with `GOEXPERIMENT=unified` and `-gcflags=-G=3`.
+run with `GOEXPERIMENT=unified` or `-gcflags=-G=3`.
 
 ```
-GOEXPERIMENT=unified go run -gcflags=-G=3 ./main.go
+GOEXPERIMENT=unified go run ./main.go
+```
+
+```
+go run -gcflags=-G=3 ./main.go
 ```


### PR DESCRIPTION
GOEXPERIMENT=unified implies -G=3, thus no need to combine both flags.
Instead, separating them, as each of them represent different mode of
the compiler.